### PR TITLE
add test environments for rockylinux8 and rockylinux9

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,6 +47,40 @@ services:
       - ../binding.gyp:/node-krb5/binding.gyp
       - ../install_krb5.sh:/node-krb5/install_krb5.sh
       - /tmp/krb5_test:/tmp/krb5_test
+  rockylinux8:
+    build: ./rockylinux8
+    image: krb5_rockylinux8
+    depends_on:
+      - kerberos
+      - rest
+    links:
+      - "kerberos:kdc.krb.local"
+      - "rest:rest.krb.local"
+    volumes:
+      - ../src:/node-krb5/src
+      - ../lib:/node-krb5/lib
+      - ../test:/node-krb5/test
+      - ../package.json:/node-krb5/package.json
+      - ../binding.gyp:/node-krb5/binding.gyp
+      - ../install_krb5.sh:/node-krb5/install_krb5.sh
+      - /tmp/krb5_test:/tmp/krb5_test
+  rockylinux9:
+    build: ./rockylinux9
+    image: krb5_rockylinux9
+    depends_on:
+      - kerberos
+      - rest
+    links:
+      - "kerberos:kdc.krb.local"
+      - "rest:rest.krb.local"
+    volumes:
+      - ../src:/node-krb5/src
+      - ../lib:/node-krb5/lib
+      - ../test:/node-krb5/test
+      - ../package.json:/node-krb5/package.json
+      - ../binding.gyp:/node-krb5/binding.gyp
+      - ../install_krb5.sh:/node-krb5/install_krb5.sh
+      - /tmp/krb5_test:/tmp/krb5_test
   centos7:
     build: ./centos7
     image: krb5_centos7

--- a/docker/rockylinux8/Dockerfile
+++ b/docker/rockylinux8/Dockerfile
@@ -1,0 +1,27 @@
+FROM rockylinux:8
+
+# Install epel (requirement for service nginx)
+RUN yum install -y epel-release
+
+RUN yum install -y scl-utils
+RUN yum install -y gcc-toolset-10
+
+# Install misc
+RUN yum install -y wget git vim sudo make
+
+# Install compilation tools
+RUN yum install -y python3 make
+
+# Install Kerberos libs
+RUN yum install -y krb5-devel
+
+# Install Node.js via n
+ENV NPM_CONFIG_LOGLEVEL info
+RUN git clone https://github.com/tj/n /n
+RUN cd /n && make install
+RUN n 16
+RUN n 18
+
+RUN mkdir -p /node-krb5
+COPY ./run.sh /run.sh
+ENTRYPOINT ["/run.sh"]

--- a/docker/rockylinux8/run.sh
+++ b/docker/rockylinux8/run.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+[[ "TRACE" ]] 
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+source scl_source enable gcc-toolset-10 # load environment configuration to use g++
+#gcc -v
+#gcc-c++ -v
+#g++ -v
+
+while [ ! -f /tmp/krb5_test/rest_ready ] 
+do
+  echo "Waiting for REST server to be ready..."
+  sleep 1
+done
+cd /node-krb5
+cp /tmp/krb5_test/krb5.conf /etc/krb5.conf
+for node_version in "16" "18"; do
+  echo "Node.js version "$node_version
+  n $node_version
+  # --unsafe-perm allows node-gyp build as root
+  # --force forces reinstallation
+  npm install --unsafe-perm --force
+  npm test
+  err=$?
+  if [ $err -ne 0 ] 
+  then
+    echo -e $RED"Tests failed for Node.js "$node_version$NC
+    exit $err
+  else
+    echo -e $GREEN"Tests passed for Node.js "$node_version$NC
+  fi
+done
+echo -e $GREEN"Tests passed for Node.js version 16 and 18"$NC
+exit 0

--- a/docker/rockylinux9/Dockerfile
+++ b/docker/rockylinux9/Dockerfile
@@ -1,0 +1,27 @@
+FROM rockylinux:9
+
+# Install epel (requirement for service nginx)
+RUN yum install -y epel-release
+
+RUN yum install -y scl-utils
+RUN yum install -y gcc-toolset-12
+
+# Install misc
+RUN yum install -y wget git vim sudo make
+
+# Install compilation tools
+RUN yum install -y python3 make
+
+# Install Kerberos libs
+RUN yum install -y krb5-devel
+
+# Install Node.js via n
+ENV NPM_CONFIG_LOGLEVEL info
+RUN git clone https://github.com/tj/n /n
+RUN cd /n && make install
+RUN n 16
+RUN n 18
+
+RUN mkdir -p /node-krb5
+COPY ./run.sh /run.sh
+ENTRYPOINT ["/run.sh"]

--- a/docker/rockylinux9/run.sh
+++ b/docker/rockylinux9/run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+[[ "TRACE" ]] 
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+source scl_source enable gcc-toolset-12 # load environment configuration to use g++
+
+while [ ! -f /tmp/krb5_test/rest_ready ] 
+do
+  echo "Waiting for REST server to be ready..."
+  sleep 1
+done
+cd /node-krb5
+cp /tmp/krb5_test/krb5.conf /etc/krb5.conf
+for node_version in "18" "16"; do
+  echo "Node.js version "$node_version
+  n $node_version
+  # --unsafe-perm allows node-gyp build as root
+  # --force forces reinstallation
+  npm install --unsafe-perm --force
+  npm test
+  err=$?
+  if [ $err -ne 0 ] 
+  then
+    echo -e $RED"Tests failed for Node.js "$node_version$NC
+    exit $err
+  else
+    echo -e $GREEN"Tests passed for Node.js "$node_version$NC
+  fi
+done
+echo -e $GREEN"Tests passed for Node.js version 16 and 18"$NC
+exit 0

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -2,7 +2,7 @@
 
 set +e
 if [ "$#" -eq 0 ];then
-	echo "No environment set: archlinux, centos7, ubuntu"
+	echo "No environment set: archlinux, centos7, rockylinux8, rockylinux9, ubuntu"
   exit 1
 fi
 


### PR DESCRIPTION
Demonstrates node-krb5 working on rockylinux8/nodejs16 but segfaulting with nodejs 18
```
git clone https://github.com/frankwallis/node-krb5.git#rockylinux
cd node-krb5/docker
git checkout rockylinux
./run_tests.sh rockylinux8
```

But working on rockylinux9/nodejs18 (and segfaulting with node16)
```
./run_tests.sh rockylinux8
```
